### PR TITLE
[FIX] truncate nickname to 32 characters

### DIFF
--- a/runbot_gitlab/models/runbot_build.py
+++ b/runbot_gitlab/models/runbot_build.py
@@ -30,7 +30,7 @@ class runbot_build(models.Model):
     @api.depends('repo_id.uses_gitlab', 'branch_id', 'name')
     def _compute_dest(self):
         for build in self.filtered('repo_id.uses_gitlab'):
-            nickname = escape_branch_name(build.branch_id.name)
+            nickname = escape_branch_name(build.branch_id.name)[:32]
             build.dest = "%05d-%s-%s" % (
                 build.id, nickname, build.name[:6]
             )


### PR DESCRIPTION
The `runbot` module truncates the nickname to 32 characters. This avoids problems with very long branch names that exceed the PostgreSQL limit for a database name.

See https://github.com/odoo/odoo-extra/blob/master/runbot/runbot.py#L497
