### PR TITLE
[FIX] runbot_buildout. Correctly select python interpreter.

### DIFF
--- a/runbot_buildout/models/runbot_build.py
+++ b/runbot_buildout/models/runbot_build.py
@@ -1,5 +1,5 @@
-# Copyright 2017-2018 Therp BV <http://therp.nl>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2017-2019 Therp BV <https://therp.nl>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 import glob
 import os
 import requests
@@ -15,6 +15,7 @@ except ImportError:
 from multiprocessing import Process
 from odoo import api, fields, models
 from odoo.addons.runbot.common import lock, grep
+
 
 MAGIC_PID_RUN_NEXT_JOB = -2
 
@@ -248,7 +249,7 @@ class RunbotBuild(models.Model):
         self._log('buildout', 'Bootstrapping buildout')
         return self._spawn(
             [
-                self._get_interpreter(),
+                self.branch_id.get_interpreter(),
                 self._path(bootstrap_file),
                 '-c', self._path('buildout.cfg'),
                 '--allow-site-packages',
@@ -446,12 +447,3 @@ class RunbotBuild(models.Model):
                 'job_end': fields.Datetime.now(),
             })
         return super(RunbotBuild, self)._local_cleanup()
-
-    @api.multi
-    def _get_interpreter(self):
-        self.ensure_one()
-        name = self.branch_id.pull_head_name or self.branch_id.name
-        if name.startswith('1') and not name.startswith('10'):
-            return '/usr/bin/python3'
-        else:
-            return '/usr/bin/python2'

--- a/runbot_buildout/tests/__init__.py
+++ b/runbot_buildout/tests/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2018 Therp BV <https://therp.nl>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from . import test_runbot_buildout
+from . import test_runbot_branch

--- a/runbot_buildout/tests/test_runbot_branch.py
+++ b/runbot_buildout/tests/test_runbot_branch.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Therp BV <https://therp.nl>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo.tests.common import SingleTransactionCase
+
+from odoo.addons.runbot_buildout.models.runbot_branch import (
+    PYTHON2, PYTHON3)
+
+
+class TestRunbotBranch(SingleTransactionCase):
+
+    def test_branch_functions(self):
+        """Create 9.0 and 11.0 buildout branch, then check python version."""
+        repo_model = self.env['runbot.repo']
+        branch_model = self.env['runbot.branch']
+        repo = repo_model.create({
+            'name': '/tmp/doesnotmatter',
+            'buildout_branch_pattern': 'buildout-(?P<version>\\d+\\.\\d+)',
+            'buildout_section': 'odoo',
+            'uses_buildout': True})
+        branch_09 = branch_model.create({
+            'name': 'refs/heads/buildout-9.0-testing',
+            'repo_id': repo.id,
+            'branch_name': 'buildout-9.0-testing'})
+        self.assertEqual(branch_09.buildout_version, '9.0')
+        self.assertEqual(branch_09.get_interpreter(), PYTHON2)
+        branch_11 = branch_model.create({
+            'name': 'refs/heads/buildout-11.0-testing',
+            'repo_id': repo.id,
+            'branch_name': 'buildout-11.0-testing'})
+        self.assertEqual(branch_11.buildout_version, '11.0')
+        self.assertEqual(branch_11.get_interpreter(), PYTHON3)


### PR DESCRIPTION
I was wandering how the buildouts for version 11.0 could complain about a missing coding line. Then I discovered these were still running under python2.

Failed to load registry
Traceback (most recent call last):
  File "/home/odorboprd11/odoo/parts/runbot/runbot/static/build/07362-11-0-5c1506/parts/odoo/odoo/modules/registry.py", line 85, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/odorboprd11/odoo/parts/runbot/runbot/static/build/07362-11-0-5c1506/parts/odoo/odoo/modules/loading.py", line 380, in load_modules
    loaded_modules, update_module, models_to_check)
  File "/home/odorboprd11/odoo/parts/runbot/runbot/static/build/07362-11-0-5c1506/parts/odoo/odoo/modules/loading.py", line 274, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/home/odorboprd11/odoo/parts/runbot/runbot/static/build/07362-11-0-5c1506/parts/odoo/odoo/modules/loading.py", line 137, in load_module_graph
    load_openerp_module(package.name)
  File "/home/odorboprd11/odoo/parts/runbot/runbot/static/build/07362-11-0-5c1506/parts/odoo/odoo/modules/module.py", line 368, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "/home/odorboprd11/odoo/parts/runbot/runbot/static/build/07362-11-0-5c1506/parts/odoo/odoo/modules/module.py", line 82, in load_module
    exec(open(modfile, 'rb').read(), new_mod.__dict__)
  File "<string>", line 4, in <module>
  File "/home/odorboprd11/odoo/parts/runbot/runbot/static/build/07362-11-0-5c1506/parts/odoo/odoo/addons/partner_contact_birthdate/models/__init__.py", line 2
SyntaxError: Non-ASCII character '\xc2' in file /home/odorboprd11/odoo/parts/runbot/runbot/static/build/07362-11-0-5c1506/parts/odoo/odoo/addons/partner_contact_birthdate/models/__init__.py on line 2, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details